### PR TITLE
chore: Remove Node v4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 4
   - 6
   - 8
   - "node"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-packager-languages",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "dist/index.js",
   "repository": "git@github.com:barinali/electron-packager-languages.git",
   "bugs": {
@@ -9,7 +9,7 @@
   "author": "Ali BARIN <ali.barin53@gmail.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">6.0.0"
   },
   "scripts": {
     "build": "babel src --out-dir dist",


### PR DESCRIPTION
As tests have been failing for a while and dependent packages stopped supporting Node v4, Node v4 support has been dropped off.