### PR TITLE
Throw error when removing all languages unless `allowRemovingAll` option is set, add debug output

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Electron Packager Plugin: Languages
 
 # Reason
 
-After packaging a MacOS application, it contains all possible languages whether it supports or not. Then all those languages are listed at the App Store. The folders of unsupported languages should be removed in order to hide those languages at the detail page of the product.
+After packaging an Electron application, it contains all possible languages whether it supports or not. Then all those languages are listed e.g. at the App Store. The folders of unsupported languages should be removed in order to hide those languages at the detail page of the product.
 
 # Usage
 
@@ -22,3 +22,6 @@ electronPackager({
   afterCopy: [setLanguages(['en', 'en_GB'])]
 })
 ```
+Note that different platforms have different language/locale identifiers, e.g. Windows has `en-GB` while macOS has `en_GB`. See also [issue #57](https://github.com/barinali/electron-packager-languages/issues/57).
+
+In order to protect users from accidentally removing all languages from an app, there's an `allowRemovingAll` option that defaults to `false`. It can be overridden like this: `setLanguages(['en', 'en_GB'], { allowRemoveAll: true })`.

--- a/src/index.js
+++ b/src/index.js
@@ -48,12 +48,16 @@ function walkLanguagePaths(dir, platform) {
   }
 }
 
-module.exports = function setLanguages(languages) {
+module.exports = function setLanguages(languages, { allowRemovingAll = false } = {}) {
   return function electronPackagerLanguages(buildPath, electronVersion, platform, arch, callback) {
     const resourcePath = getLanguageFolderPath(buildPath, platform);
     const excludedLanguages = languages.map(l => `${l}.${getLanguageFileExtension(platform)}`);
     const languageFolders = walkLanguagePaths(resourcePath, platform);
     const excludedFolders = languageFolders.filter(langFolder => !excludedLanguages.includes(langFolder));
+    
+    if(allowRemovingAll !== true && excludedFolders.length === languageFolders.length) {
+      throw new Error('electron-packager-languages: Refusing to remove all languages from the packaged app! Double check the supplied locale identifiers or suppress this error via the "allowRemovingAll" option.');
+    }
 
     d('Removing %d of %d languages from the packaged app.', excludedFolders.length, languageFolders.length);
     excludedFolders.forEach(langFolder => rimraf.sync(path.resolve(resourcePath, langFolder)));

--- a/src/index.js
+++ b/src/index.js
@@ -51,9 +51,9 @@ function walkLanguagePaths(dir, platform) {
 module.exports = function setLanguages(languages, { allowRemovingAll = false } = {}) {
   return function electronPackagerLanguages(buildPath, electronVersion, platform, arch, callback) {
     const resourcePath = getLanguageFolderPath(buildPath, platform);
-    const excludedLanguages = languages.map(l => `${l}.${getLanguageFileExtension(platform)}`);
+    const includedLanguages = languages.map(l => `${l}.${getLanguageFileExtension(platform)}`);
     const languageFolders = walkLanguagePaths(resourcePath, platform);
-    const excludedFolders = languageFolders.filter(langFolder => !excludedLanguages.includes(langFolder));
+    const excludedFolders = languageFolders.filter(langFolder => !includedLanguages.includes(langFolder));
     
     if(allowRemovingAll !== true && excludedFolders.length === languageFolders.length) {
       throw new Error('electron-packager-languages: Refusing to remove all languages from the packaged app! Double check the supplied locale identifiers or suppress this error via the "allowRemovingAll" option.');

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,9 @@
 const fs = require('fs');
 const path = require('path');
 const rimraf = require('rimraf');
+const debug = require('debug');
+
+const d = debug('electron-forge:packager:languages');
 
 function getLanguageFolderPath(givenPath, platform) {
   switch (platform) {
@@ -50,10 +53,10 @@ module.exports = function setLanguages(languages) {
     const resourcePath = getLanguageFolderPath(buildPath, platform);
     const excludedLanguages = languages.map(l => `${l}.${getLanguageFileExtension(platform)}`);
     const languageFolders = walkLanguagePaths(resourcePath, platform);
+    const excludedFolders = languageFolders.filter(langFolder => !excludedLanguages.includes(langFolder));
 
-    languageFolders
-      .filter(langFolder => !excludedLanguages.includes(langFolder))
-      .forEach(langFolder => rimraf.sync(path.resolve(resourcePath, langFolder)));
+    d('Removing %d of %d languages from the packaged app.', excludedFolders.length, languageFolders.length);
+    excludedFolders.forEach(langFolder => rimraf.sync(path.resolve(resourcePath, langFolder)));
 
     callback();
   };

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const path = require('path');
 const rimraf = require('rimraf');
 const debug = require('debug');
 
-const d = debug('electron-forge:packager:languages');
+const d = debug('electron-packager-languages');
 
 function getLanguageFolderPath(givenPath, platform) {
   switch (platform) {


### PR DESCRIPTION
A newly implemented `allowRemovingAll` option that defaults to `false` protects users from accidentally removing all languages from a packaged app, leading to hard-to-spot bugs like the one described in #11 and electron/electron#45251.