### PR TITLE
Handle variations of language identifiers across platforms

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,9 +51,18 @@ function walkLanguagePaths(dir, platform) {
 module.exports = function setLanguages(languages, { allowRemovingAll = false } = {}) {
   return function electronPackagerLanguages(buildPath, electronVersion, platform, arch, callback) {
     const resourcePath = getLanguageFolderPath(buildPath, platform);
-    const includedLanguages = languages.map(l => `${l}.${getLanguageFileExtension(platform)}`);
     const languageFolders = walkLanguagePaths(resourcePath, platform);
-    const excludedFolders = languageFolders.filter(langFolder => !includedLanguages.includes(langFolder));
+
+    const includedLanguages = languages.flatMap(l => {
+      // Make sure possible variations of language identifiers across
+      // platforms are covered, e.g. "en_US", "en-US", "en_us", "en-us"
+      return [
+        `${l.replace('_', '-').toLowerCase()}.${getLanguageFileExtension(platform)}`,
+        `${l.replace('-', '_').toLowerCase()}.${getLanguageFileExtension(platform)}`,
+      ];
+    });
+
+    const excludedFolders = languageFolders.filter(langFolder => !includedLanguages.includes(langFolder.toLowerCase()));
 
     if (allowRemovingAll !== true && excludedFolders.length === languageFolders.length) {
       throw new Error('electron-packager-languages: Refusing to remove all languages from the packaged app! Double check the supplied locale identifiers or suppress this error via the "allowRemovingAll" option.');


### PR DESCRIPTION
I think simply aliasing `_` and `-` and ignoring case would solve #57.

Indirectly related to my issue electron/electron#45251.